### PR TITLE
feat: add temperaturePollingInterval for optimized EC querying

### DIFF
--- a/adjustable_polling_interval.md
+++ b/adjustable_polling_interval.md
@@ -1,0 +1,152 @@
+Sure! Here's a full-featured, user-friendly Markdown documentation page for your new feature: `temperaturePollingInterval`.
+
+---
+
+# 🔧 `temperaturePollingInterval` — Reduce EC Load with Smarter Temperature Polling
+
+Framework laptops use EC (Embedded Controller) queries to read temperature data, which can be resource-sensitive.
+With the addition of `temperaturePollingInterval`, you now have **fine-grained control** over how often temperatures are read — **independent from how often fan speed is updated**.
+
+---
+
+## ✨ What Is It?
+
+`temperaturePollingInterval` is a new configuration option in each strategy that defines how often (in seconds) the EC is queried for a fresh temperature reading.
+
+By default, fan speed and temperature were both checked once per second. Now, with this setting, you can **reduce polling frequency**, which:
+
+* ✅ Decreases EC overhead
+* ✅ Reduces system jitter or fan controller instability
+* ✅ Helps battery life slightly when on DC
+
+---
+
+## ⚙️ Where Does It Go?
+
+This is a **per-strategy setting**, defined in your `config.json` like this:
+
+```json
+{
+  "defaultStrategy": "balanced",
+  "strategyOnDischarging": "quiet",
+  "strategies": {
+    "balanced": {
+      "fanSpeedUpdateFrequency": 3,
+      "movingAverageInterval": 30,
+      "temperaturePollingInterval": 3,
+      "speedCurve": [
+        { "temp": 40, "speed": 0 },
+        { "temp": 70, "speed": 100 }
+      ]
+    }
+  },
+  "$schema": "./config.schema.json"
+}
+```
+
+---
+
+## 📐 How Does It Work?
+
+### Before:
+
+```python
+get_actual_temperature()  # Called every second
+adapt_speed(temp)         # Called every fanSpeedUpdateFrequency
+```
+
+### Now:
+
+* The EC is queried only **once every `temperaturePollingInterval` seconds**
+* That value is **cached** between reads
+* Fan speed is still updated independently
+
+---
+
+## 🧪 Example Use Cases
+
+### 🔇 Quiet Mode
+
+```json
+"quiet": {
+  "fanSpeedUpdateFrequency": 10,
+  "movingAverageInterval": 60,
+  "temperaturePollingInterval": 5,
+  ...
+}
+```
+
+> Great for reducing noise and EC spam while on battery.
+
+---
+
+### 🐝 Aggressive Mode
+
+```json
+"performance": {
+  "fanSpeedUpdateFrequency": 2,
+  "movingAverageInterval": 10,
+  "temperaturePollingInterval": 1,
+  ...
+}
+```
+
+> Keeps your system cool and responsive at the cost of more EC interaction.
+
+---
+
+## 🧑‍💻 Runtime Modification (CLI)
+
+You can change this without editing the file manually:
+
+```bash
+fw-fanctrl set_strategy_param balanced temperaturePollingInterval 5
+```
+
+This:
+
+* Updates `config.json`
+* Reloads the strategy live if it's active
+* Persists across reboots
+
+---
+
+## 📏 Constraints & Schema
+
+* Type: `integer`
+* Range: `1–60` seconds
+* Optional (defaults to `1` if missing)
+
+Defined in schema as:
+
+```json
+"temperaturePollingInterval": {
+  "type": "integer",
+  "minimum": 1,
+  "maximum": 60,
+  "description": "How often (in seconds) to query the EC for temperature. Reduces load on EC."
+}
+```
+
+---
+
+## 📝 Recommendations
+
+| Scenario               | Recommended Interval           |
+| ---------------------- | ------------------------------ |
+| On battery (quiet)     | 5–10 seconds                   |
+| Light daily use        | 3–5 seconds                    |
+| Gaming / performance   | 1–2 seconds                    |
+| Benchmarking / testing | 1 second (or lower if allowed) |
+
+---
+
+## 🧠 TL;DR
+
+* Add `"temperaturePollingInterval": X` in your strategy block
+* Avoids hammering the EC every second
+* Keeps your Framework system calm, cool, and stable 🧊
+
+---
+
+Let me know if you want a badge, diagram, or animated example showing polling vs fan updating visually!

--- a/adjustable_polling_interval.md
+++ b/adjustable_polling_interval.md
@@ -137,7 +137,7 @@ Defined in schema as:
 | On battery (quiet)     | 5–10 seconds                   |
 | Light daily use        | 3–5 seconds                    |
 | Gaming / performance   | 1–2 seconds                    |
-| Benchmarking / testing | 1 second (or lower if allowed) |
+| Benchmarking / testing | 1 second (minimum allowed by schema) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fw-fanctrl"
-version = "1.0.3"
+version = "1.0.4"
 description = "A simple systemd service to better control Framework Laptop's fan(s)."
 keywords = ["framework", "laptop", "fan", "control", "cli", "service"]
 readme = "README.md"
@@ -36,6 +36,7 @@ authors = [
 maintainers = [
     { name = "TamtamHero" },
     { name = "leopoldhub" },
+    { name = "tayjaybabee" },
 ]
 license = { file = "LICENSE" }
 classifiers = [

--- a/src/fw_fanctrl/CommandParser.py
+++ b/src/fw_fanctrl/CommandParser.py
@@ -47,6 +47,27 @@ class CommandParser:
         commands_sub_parser = self.parser.add_subparsers(dest="command")
         commands_sub_parser.required = True
 
+        set_param_command = commands_sub_parser.add_parser(
+            "set_strategy_param",
+            description="Set a single parameter value in a strategy",
+            formatter_class=argparse.RawTextHelpFormatter
+        )
+
+        set_param_command.add_argument(
+            "strategy",
+            help="Name of the strategy to modify."
+        )
+
+        set_param_command.add_argument(
+            "param",
+            help="Name of the parameter to update (e.g. temperaturePollingInterval)."
+        )
+
+        set_param_command.add_argument(
+            "value",
+            help="The value to set (will be parsed as int if possible)."
+        )
+
         if not self.is_remote:
             run_command = commands_sub_parser.add_parser(
                 "run",

--- a/src/fw_fanctrl/Configuration.py
+++ b/src/fw_fanctrl/Configuration.py
@@ -1,5 +1,4 @@
 import json
-import copy
 from json import JSONDecodeError
 from os.path import isfile
 from shutil import copyfile
@@ -75,78 +74,51 @@ class Configuration:
     def get_discharging_strategy(self):
         return self.get_strategy("strategyOnDischarging")
 
-    def update_strategy_param(self, strategy_name, param, value):
-        """Update a single strategy parameter with schema validation."""
+    def coerce_strategy_param(self, strategy_name, param, value):
+        """Coerce a parameter value according to the schema."""
         if strategy_name not in self.data["strategies"]:
             raise InvalidStrategyException(strategy_name)
 
-        strategy = self.data["strategies"][strategy_name]
-
-        if param not in strategy:
+        strategy_schema = VALIDATION_SCHEMA["$defs"]["strategy"]["properties"]
+        if param not in strategy_schema:
+            valid_params = ", ".join(sorted(strategy_schema.keys()))
             raise ConfigurationParsingException(
-                f"Unknown parameter '{param}' for strategy '{strategy_name}'"
+                f"Unknown parameter '{param}' for strategy '{strategy_name}'. "
+                f"Valid parameters are: {valid_params}"
             )
 
-        current_value = strategy[param]
-
-        if isinstance(current_value, list):
-            raise ConfigurationParsingException(
-                f"Editing list parameter '{param}' is not supported via CLI"
-            )
+        expected_type = strategy_schema[param].get("type")
 
         try:
-            if isinstance(current_value, bool):
+            if expected_type == "boolean":
                 if isinstance(value, str):
                     if value.lower() in ("true", "1", "yes", "on"):
-                        value = True
-                    elif value.lower() in ("false", "0", "no", "off"):
-                        value = False
-                    else:
-                        raise ValueError(f"Cannot convert '{value}' to bool")
-                else:
-                    value = bool(value)
-            else:
-                value = type(current_value)(value)
+                        return True
+                    if value.lower() in ("false", "0", "no", "off"):
+                        return False
+                    raise ValueError
+                return bool(value)
+            if expected_type == "integer":
+                return int(value)
+            if expected_type == "number":
+                return float(value)
+            if expected_type == "array":
+                raise ConfigurationParsingException(f"Editing list parameter '{param}' is not supported via CLI")
+            return str(value)
         except (TypeError, ValueError) as e:
-            raise ConfigurationParsingException(
-                f"Invalid value for '{param}': {value}"
-            ) from e
+            raise ConfigurationParsingException(f"Invalid value for '{param}': {value}") from e
 
-        if prop_schema := VALIDATION_SCHEMA["$defs"]["strategy"]["properties"].get(
-            param
-        ):
-            minimum = prop_schema.get("minimum")
-            maximum = prop_schema.get("maximum")
-            if (minimum is not None and value < minimum) or (
-                maximum is not None and value > maximum
-            ):
-                raise ConfigurationParsingException(
-                    f"{param} must be between {minimum} and {maximum}"
-                )
+    def update_strategy_param(self, strategy_name, param, value):
+        """Update a single strategy parameter with schema validation."""
+        coerced = self.coerce_strategy_param(strategy_name, param, value)
+        strategy = self.data["strategies"][strategy_name]
+        old_value = strategy.get(param)
+        strategy[param] = coerced
 
-You can drop the full deep‐copy + JSON round‐trip and validate in‐place. For example:
+        try:
+            jsonschema.validate(self.data, VALIDATION_SCHEMA)
+        except jsonschema.ValidationError as e:
+            strategy[param] = old_value
+            raise ConfigurationParsingException(f"Schema violation: {e.message}") from e
 
-```python
-import jsonschema
-
-def update_strategy_param(self, strategy_name, param, value):
-    # … pre‐checks, type coercion, manual range checks …
-
-    # 1) In‐place update
-    self.data["strategies"][strategy_name][param] = value
-
-    # 2) Direct schema validation
-    try:
-        jsonschema.validate(self.data, VALIDATION_SCHEMA)
-    except jsonschema.ValidationError as e:
-        # revert on failure
-        # (optional) self.reload()  or cache old value before mutation
-        raise ConfigurationParsingException(f"Schema violation: {e.message}") from e
-
-    # 3) Persist
-    self.save()
-        new_data["strategies"][strategy_name][param] = value
-
-        # Validate against schema and commit
-        self.data = self.parse(json.dumps(new_data))
         self.save()

--- a/src/fw_fanctrl/Strategy.py
+++ b/src/fw_fanctrl/Strategy.py
@@ -6,10 +6,25 @@ class Strategy:
 
     def __init__(self, name, parameters):
         self.name = name
+
         self.fan_speed_update_frequency = parameters["fanSpeedUpdateFrequency"]
+
         if self.fan_speed_update_frequency is None or self.fan_speed_update_frequency == "":
             self.fan_speed_update_frequency = 5
+
         self.moving_average_interval = parameters["movingAverageInterval"]
+
         if self.moving_average_interval is None or self.moving_average_interval == "":
             self.moving_average_interval = 20
+
+        self.temperature_polling_interval = parameters.get("temperaturePollingInterval", 1) or 1
+
         self.speed_curve = parameters["speedCurve"]
+
+    def to_dict(self):
+        return {
+            "fanSpeedUpdateFrequency": self.fan_speed_update_frequency,
+            "movingAverageInterval": self.moving_average_interval,
+            "temperaturePollingInterval": self.temperature_polling_interval,
+            "speedCurve": self.speed_curve
+        }

--- a/src/fw_fanctrl/_resources/config.schema.json
+++ b/src/fw_fanctrl/_resources/config.schema.json
@@ -78,6 +78,12 @@
                     "maximum": 100,
                     "description": "The time window (in seconds) over which temperature readings are averaged."
                 },
+                "temperaturePollingInterval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 60,
+                    "description": "How often (in seconds) to query the EC for temperature. Reduces load on EC."
+                  },
                 "speedCurve": {
                     "type": "array",
                     "minItems": 1,


### PR DESCRIPTION
## Summary by Sourcery

Enable configurable temperature polling intervals per strategy with live CLI updates and refactor controller loop to optimize EC queries and fan-speed scheduling

New Features:
- Add "temperaturePollingInterval" parameter to strategies to control how often EC temperature reads occur
- Introduce scheduled and cached temperature polling in FanController to decouple temperature reads from fan speed updates
- Add "set_strategy_param" CLI command to update strategy parameters at runtime with schema validation

Enhancements:
- Refactor FanController.run to use time.monotonic scheduling and variable sleep intervals instead of a simple counter

Build:
- Bump project version to 1.0.4

Documentation:
- Add markdown documentation for the "temperaturePollingInterval" feature