### PR TITLE
Centralize param validation and adjust scheduling

### DIFF
--- a/src/fw_fanctrl/Configuration.py
+++ b/src/fw_fanctrl/Configuration.py
@@ -1,5 +1,4 @@
 import json
-import copy
 from json import JSONDecodeError
 from os.path import isfile
 from shutil import copyfile
@@ -75,78 +74,47 @@ class Configuration:
     def get_discharging_strategy(self):
         return self.get_strategy("strategyOnDischarging")
 
-    def update_strategy_param(self, strategy_name, param, value):
-        """Update a single strategy parameter with schema validation."""
+    def coerce_strategy_param(self, strategy_name, param, value):
+        """Coerce a parameter value according to the schema."""
         if strategy_name not in self.data["strategies"]:
             raise InvalidStrategyException(strategy_name)
 
-        strategy = self.data["strategies"][strategy_name]
+        strategy_schema = VALIDATION_SCHEMA["$defs"]["strategy"]["properties"]
+        if param not in strategy_schema:
+            raise ConfigurationParsingException(f"Unknown parameter '{param}' for strategy '{strategy_name}'")
 
-        if param not in strategy:
-            raise ConfigurationParsingException(
-                f"Unknown parameter '{param}' for strategy '{strategy_name}'"
-            )
-
-        current_value = strategy[param]
-
-        if isinstance(current_value, list):
-            raise ConfigurationParsingException(
-                f"Editing list parameter '{param}' is not supported via CLI"
-            )
+        expected_type = strategy_schema[param].get("type")
 
         try:
-            if isinstance(current_value, bool):
+            if expected_type == "boolean":
                 if isinstance(value, str):
                     if value.lower() in ("true", "1", "yes", "on"):
-                        value = True
-                    elif value.lower() in ("false", "0", "no", "off"):
-                        value = False
-                    else:
-                        raise ValueError(f"Cannot convert '{value}' to bool")
-                else:
-                    value = bool(value)
-            else:
-                value = type(current_value)(value)
+                        return True
+                    if value.lower() in ("false", "0", "no", "off"):
+                        return False
+                    raise ValueError
+                return bool(value)
+            if expected_type == "integer":
+                return int(value)
+            if expected_type == "number":
+                return float(value)
+            if expected_type == "array":
+                raise ConfigurationParsingException(f"Editing list parameter '{param}' is not supported via CLI")
+            return str(value)
         except (TypeError, ValueError) as e:
-            raise ConfigurationParsingException(
-                f"Invalid value for '{param}': {value}"
-            ) from e
+            raise ConfigurationParsingException(f"Invalid value for '{param}': {value}") from e
 
-        if prop_schema := VALIDATION_SCHEMA["$defs"]["strategy"]["properties"].get(
-            param
-        ):
-            minimum = prop_schema.get("minimum")
-            maximum = prop_schema.get("maximum")
-            if (minimum is not None and value < minimum) or (
-                maximum is not None and value > maximum
-            ):
-                raise ConfigurationParsingException(
-                    f"{param} must be between {minimum} and {maximum}"
-                )
+    def update_strategy_param(self, strategy_name, param, value):
+        """Update a single strategy parameter with schema validation."""
+        coerced = self.coerce_strategy_param(strategy_name, param, value)
+        strategy = self.data["strategies"][strategy_name]
+        old_value = strategy.get(param)
+        strategy[param] = coerced
 
-You can drop the full deep‐copy + JSON round‐trip and validate in‐place. For example:
+        try:
+            jsonschema.validate(self.data, VALIDATION_SCHEMA)
+        except jsonschema.ValidationError as e:
+            strategy[param] = old_value
+            raise ConfigurationParsingException(f"Schema violation: {e.message}") from e
 
-```python
-import jsonschema
-
-def update_strategy_param(self, strategy_name, param, value):
-    # … pre‐checks, type coercion, manual range checks …
-
-    # 1) In‐place update
-    self.data["strategies"][strategy_name][param] = value
-
-    # 2) Direct schema validation
-    try:
-        jsonschema.validate(self.data, VALIDATION_SCHEMA)
-    except jsonschema.ValidationError as e:
-        # revert on failure
-        # (optional) self.reload()  or cache old value before mutation
-        raise ConfigurationParsingException(f"Schema violation: {e.message}") from e
-
-    # 3) Persist
-    self.save()
-        new_data["strategies"][strategy_name][param] = value
-
-        # Validate against schema and commit
-        self.data = self.parse(json.dumps(new_data))
         self.save()


### PR DESCRIPTION
## Summary
- remove inline review snippet from `Configuration`
- add `coerce_strategy_param` helper for type conversion
- validate configuration in-place in `update_strategy_param`
- use the coercion helper in `FanController`
- resync loop timing on strategy changes

## Testing
- `python -m py_compile src/fw_fanctrl/*.py`
- `black --check src/fw_fanctrl/Configuration.py src/fw_fanctrl/FanController.py`

------
https://chatgpt.com/codex/tasks/task_e_6889318d8f70832d803d6acd0522612d